### PR TITLE
Removed the duplicate task from playbook.yml

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,0 +1,2 @@
+---
+dest: /var/www/html/index.html

--- a/host_vars/node2.yml
+++ b/host_vars/node2.yml
@@ -1,2 +1,2 @@
+---
 source: ./html/index-1.html
-dest: /var/www/html/index.html

--- a/host_vars/node3.yml
+++ b/host_vars/node3.yml
@@ -1,2 +1,2 @@
+---
 source: ./html/index-2.html
-dest: /var/www/html/index.html

--- a/playbook.yml
+++ b/playbook.yml
@@ -38,7 +38,7 @@
     - name: Deploy updated index.html file 
       copy: 
         src: "{{ source }}"
-        dest: /var/www/html/index.html
+        dest: "{{ dest }}"
         mode: 0644
 
     # Change this to whatever directory your Ansible playbook lives in 

--- a/playbook.yml
+++ b/playbook.yml
@@ -26,39 +26,6 @@
   roles:
     - apache2
 
-# Deploy the custom index file to node 2  
-- hosts: node2
-  remote_user: pi
-  become: yes
-  gather_facts: no
-
-  tasks:
-
-    # Change this to whatever directory your Ansible playbook lives in 
-    # Ex: /some-folder/another-folder/ansible/python/ledON.py
-    - name: Visually indicate which server we are deploying to
-      script: ./python/ledON.py
-      changed_when: false
-
-    # Apache's default web directory is /var/www/html on the Pi
-    - name: Deploy updated index.html file 
-      copy: 
-        src: "{{ source }}"
-        dest: "{{ dest }}"
-        mode: 0644
-
-    # Change this to whatever directory your Ansible playbook lives in 
-    # Ex: /some-folder/another-folder/ansible/python/ledON.py
-    - name: Visually indicate that we are done deplying to the server
-      script: ./python/ledOFF.py
-      changed_when: false
-
-# Deploy the custom index file to node 3
-- hosts: node3
-  remote_user: pi
-  become: yes
-  gather_facts: no
-
   tasks:
 
     # Change this to whatever directory your Ansible playbook lives in 
@@ -71,7 +38,7 @@
     - name: Deploy updated index.html file 
       copy: 
         src: "{{ source }}"
-        dest: "{{ dest }}"
+        dest: /var/www/html/index.html
         mode: 0644
 
     # Change this to whatever directory your Ansible playbook lives in 


### PR DESCRIPTION
Now that you've moved those variables into the `host_vars`, you should be able to streamline down to a single task to deploy the HTML for both nodes, while still uniquely deploying separate HTML files.

I also moved the variable `dest` to the `group_vars` because that's a global variable, and not unique to each host.